### PR TITLE
Create Command

### DIFF
--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -12,11 +12,11 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with: 
-        go-version: '1.14.0'
+        go-version: '1.13.0'
 
     - name: Run build
-      run: go build ./cmd/main.go
+      run: go build ./...
 
     - name: Run testing
-      run: go test -v ./cmd
+      run: go test -v ./...
       

--- a/cmd/go-grade-view/main.go
+++ b/cmd/go-grade-view/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"log"
+)
+
+func main() {
+	log.Println("Main started")
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,9 +1,0 @@
-package main
-
-import (
-	"log"
-)
-
-func main() {
-	log.Println("Main started")
-}


### PR DESCRIPTION
Move main go file into sub-directory under /cmd to match module project structure and facilitate correct command creation with go build. Update workflow to match this change as well as match go version 1.13.  Should replace #6.